### PR TITLE
Add CI workflow and Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI Build
+
+on:
+  workflow_dispatch:
+  push:    
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET (global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Build
+        env:
+          DOTNET_NUGET_SIGNATURE_VERIFICATION: false
+        run: dotnet build hearts.sln
+      - name: Test
+        run: |
+            dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover \
+            test/Hearts.Api.UnitTests/Hearts.Api.UnitTests.csproj
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ngruson/hearts


### PR DESCRIPTION
- Introduced `dependabot.yml` to manage NuGet version updates weekly.
- Created `ci.yml` for CI build workflow with steps for checkout, .NET setup, build, test with coverage, and Codecov report upload.