### PR TITLE
25 improve distributed traces

### DIFF
--- a/src/Hearts.Api/GameHub.cs
+++ b/src/Hearts.Api/GameHub.cs
@@ -28,7 +28,7 @@ public class GameHub(DaprWorkflowClient daprWorkflowClient, Instrumentation inst
             return;            
         }
 
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(CreatePlayer));
+        using Activity? activity = instrumentation.StartActivity(nameof(CreatePlayer));
 
         ActorId actorId = new(Guid.CreateVersion7().ToString());
         IPlayerActor playerActor = ActorProxy.Create<IPlayerActor>(actorId, nameof(PlayerActor));
@@ -39,7 +39,7 @@ public class GameHub(DaprWorkflowClient daprWorkflowClient, Instrumentation inst
 
     public async Task CreateNewGame(Player player)
     {        
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(CreateNewGame));
+        using Activity? activity = instrumentation.StartActivity(nameof(CreateNewGame));
 
         if (activity is null)
             return;
@@ -50,7 +50,7 @@ public class GameHub(DaprWorkflowClient daprWorkflowClient, Instrumentation inst
 
     public async Task PassCards(Guid gameId, string workflowInstanceId, PassCard[] passCards)
     {
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(PassCards));
+        using Activity? activity = instrumentation.StartActivity(nameof(PassCards));
 
         await daprWorkflowClient.RaiseEventAsync(workflowInstanceId,
             GameWorkflowEvents.CardsPassed,

--- a/src/Hearts.Api/GameHub.cs
+++ b/src/Hearts.Api/GameHub.cs
@@ -1,14 +1,16 @@
+using System.Diagnostics;
 using Dapr.Actors;
 using Dapr.Actors.Client;
 using Dapr.Workflow;
 using Hearts.Api.Actors;
+using Hearts.Api.OpenTelemetry;
 using Hearts.Api.Workflows;
 using Hearts.Contracts;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Hearts.Api;
 
-public class GameHub(DaprWorkflowClient daprWorkflowClient) : Hub<IGameClient>
+public class GameHub(DaprWorkflowClient daprWorkflowClient, Instrumentation instrumentation) : Hub<IGameClient>
 {
     public new virtual IHubCallerClients<IGameClient> Clients
     {
@@ -26,6 +28,8 @@ public class GameHub(DaprWorkflowClient daprWorkflowClient) : Hub<IGameClient>
             return;            
         }
 
+        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(CreatePlayer));
+
         ActorId actorId = new(Guid.CreateVersion7().ToString());
         IPlayerActor playerActor = ActorProxy.Create<IPlayerActor>(actorId, nameof(PlayerActor));
         Player player = new(Guid.Parse(actorId.GetId()), name);
@@ -34,13 +38,20 @@ public class GameHub(DaprWorkflowClient daprWorkflowClient) : Hub<IGameClient>
     }
 
     public async Task CreateNewGame(Player player)
-    {
-        GameWorkflowInput input = new(player);
+    {        
+        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(CreateNewGame));
+
+        if (activity is null)
+            return;
+
+        GameWorkflowInput input = new(activity.TraceId.ToString(), activity.SpanId.ToString(), player);
         await daprWorkflowClient.ScheduleNewWorkflowAsync(nameof(GameWorkflow), null, input);
     }
 
     public async Task PassCards(Guid gameId, string workflowInstanceId, PassCard[] passCards)
     {
+        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(PassCards));
+
         await daprWorkflowClient.RaiseEventAsync(workflowInstanceId,
             GameWorkflowEvents.CardsPassed,
             new CardsPassedEvent(gameId, passCards));

--- a/src/Hearts.Api/OpenTelemetry/Instrumentation.cs
+++ b/src/Hearts.Api/OpenTelemetry/Instrumentation.cs
@@ -4,10 +4,15 @@ namespace Hearts.Api.OpenTelemetry;
 
 public class Instrumentation
 {
-    public ActivitySource ActivitySource => new("Hearts.Api");
+    private readonly ActivitySource activitySource = new("Hearts.Api");
+
+    public virtual Activity? StartActivity(string name, ActivityKind kind = ActivityKind.Internal)
+    {
+        return this.activitySource.StartActivity(name, kind);
+    }
 
     public virtual Activity? StartActivity(string name, ActivityKind kind, ActivityContext parentContext)
     {
-        return this.ActivitySource.StartActivity(name, kind, parentContext);
+        return this.activitySource.StartActivity(name, kind, parentContext);
     }
 }

--- a/src/Hearts.Api/OpenTelemetry/Instrumentation.cs
+++ b/src/Hearts.Api/OpenTelemetry/Instrumentation.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace Hearts.Api.OpenTelemetry;
+
+public class Instrumentation
+{
+    public ActivitySource ActivitySource => new("Hearts.Api");
+
+    public virtual Activity? StartActivity(string name, ActivityKind kind, ActivityContext parentContext)
+    {
+        return this.ActivitySource.StartActivity(name, kind, parentContext);
+    }
+}

--- a/src/Hearts.Api/Program.cs
+++ b/src/Hearts.Api/Program.cs
@@ -1,6 +1,7 @@
 using Dapr.Workflow;
 using Hearts.Api;
 using Hearts.Api.Actors;
+using Hearts.Api.OpenTelemetry;
 using Hearts.Api.Workflows;
 using Hearts.ServiceDefaults;
 
@@ -29,6 +30,7 @@ builder.Services.AddDaprWorkflow(options =>
 builder.Services.AddSignalR();
 builder.Services.AddSingleton<GameHub>();
 builder.Services.AddSingleton<IClientCallback, ClientCallback>();
+builder.Services.AddSingleton<Instrumentation>();
 
 builder.Services.AddCors();
 

--- a/src/Hearts.Api/Workflows/AddBotPlayerActivity.cs
+++ b/src/Hearts.Api/Workflows/AddBotPlayerActivity.cs
@@ -15,7 +15,7 @@ internal class AddBotPlayerActivity(IActorProxyFactory actorProxyFactory, Instru
     public override async Task<Result<Game>> RunAsync(WorkflowActivityContext context, AddBotPlayerActivityInput input)
     {
         ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(AddBotPlayerActivity), ActivityKind.Internal, activityContext);
+        using Activity? activity = instrumentation.StartActivity(nameof(AddBotPlayerActivity), ActivityKind.Internal, activityContext);
 
         try
         {

--- a/src/Hearts.Api/Workflows/AddBotPlayerActivity.cs
+++ b/src/Hearts.Api/Workflows/AddBotPlayerActivity.cs
@@ -1,17 +1,22 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Ardalis.Result;
 using Dapr.Actors;
 using Dapr.Actors.Client;
 using Dapr.Workflow;
 using Hearts.Api.Actors;
+using Hearts.Api.OpenTelemetry;
 using Hearts.Contracts;
 
 namespace Hearts.Api.Workflows;
 
-internal class AddBotPlayerActivity(IActorProxyFactory actorProxyFactory) : WorkflowActivity<AddBotPlayerActivityInput, Result<Game>>
+internal class AddBotPlayerActivity(IActorProxyFactory actorProxyFactory, Instrumentation instrumentation) : WorkflowActivity<AddBotPlayerActivityInput, Result<Game>>
 {
     public override async Task<Result<Game>> RunAsync(WorkflowActivityContext context, AddBotPlayerActivityInput input)
     {
+        ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
+        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(AddBotPlayerActivity), ActivityKind.Internal, activityContext);
+
         try
         {
             ActorProxyOptions actorProxyOptions = new()
@@ -34,6 +39,7 @@ internal class AddBotPlayerActivity(IActorProxyFactory actorProxyFactory) : Work
         }
         catch (Exception ex)
         {
+            activity?.AddException(ex);
             return Result.Error(ex.Message);
         }
     }

--- a/src/Hearts.Api/Workflows/AddBotPlayerActivityInput.cs
+++ b/src/Hearts.Api/Workflows/AddBotPlayerActivityInput.cs
@@ -1,3 +1,3 @@
 namespace Hearts.Api.Workflows;
 
-record AddBotPlayerActivityInput(Guid GameId);
+record AddBotPlayerActivityInput(string TraceId, string SpanId, Guid GameId);

--- a/src/Hearts.Api/Workflows/CardsPassedActivity.cs
+++ b/src/Hearts.Api/Workflows/CardsPassedActivity.cs
@@ -14,7 +14,7 @@ public class CardsPassedActivity(IActorProxyFactory actorProxyFactory, Instrumen
     public override async Task<Result> RunAsync(WorkflowActivityContext context, CardsPassedActivityInput input)
     {
         ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(CardsPassedActivity), ActivityKind.Internal, activityContext);
+        using Activity? activity = instrumentation.StartActivity(nameof(CardsPassedActivity), ActivityKind.Internal, activityContext);
 
         try
         {

--- a/src/Hearts.Api/Workflows/CardsPassedActivityInput.cs
+++ b/src/Hearts.Api/Workflows/CardsPassedActivityInput.cs
@@ -1,0 +1,3 @@
+namespace Hearts.Api.Workflows;
+
+public record CardsPassedActivityInput(string TraceId, string SpanId, CardsPassedEvent CardsPassedEvent);

--- a/src/Hearts.Api/Workflows/CreateNewGameActivity.cs
+++ b/src/Hearts.Api/Workflows/CreateNewGameActivity.cs
@@ -15,7 +15,7 @@ internal class CreateNewGameActivity(IActorProxyFactory actorProxyFactory, Instr
     public override async Task<Result<Game>> RunAsync(WorkflowActivityContext context, CreateNewGameActivityInput input)
     {
         ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(CreateNewGameActivity), ActivityKind.Internal, activityContext);
+        using Activity? activity = instrumentation.StartActivity(nameof(CreateNewGameActivity), ActivityKind.Internal, activityContext);
 
         try
         {

--- a/src/Hearts.Api/Workflows/CreateNewGameActivityInput.cs
+++ b/src/Hearts.Api/Workflows/CreateNewGameActivityInput.cs
@@ -1,5 +1,6 @@
+using System.Diagnostics;
 using Hearts.Contracts;
 
 namespace Hearts.Api.Workflows;
 
-record CreateNewGameActivityInput(Player Player);
+record CreateNewGameActivityInput(string TraceId, string SpanId, Player Player);

--- a/src/Hearts.Api/Workflows/GameWorkflow.cs
+++ b/src/Hearts.Api/Workflows/GameWorkflow.cs
@@ -1,24 +1,36 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using Dapr.Workflow;
+using Hearts.Api.OpenTelemetry;
 using Hearts.Contracts;
 
 namespace Hearts.Api.Workflows;
 
 internal class GameWorkflow : Workflow<GameWorkflowInput, Result>
 {
+    public Instrumentation Instrumentation { get; set; } = new();
+
     public override async Task<Result> RunAsync(WorkflowContext context, GameWorkflowInput input)
     {
+        ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
+        using Activity? activity = this.Instrumentation.StartActivity(nameof(GameWorkflow), ActivityKind.Internal, activityContext);
+
+        if (activity is null)
+        {
+            return Result.Error("Failed to start activity");
+        }
+
         try
         {
             Result<Game> createNewGameResult = await context.CallActivityAsync<Result<Game>>(
                 nameof(CreateNewGameActivity),
-                new CreateNewGameActivityInput(input.Player));
+                new CreateNewGameActivityInput(activity.TraceId.ToString(), activity.SpanId.ToString(), input.Player));
 
             if (createNewGameResult.IsSuccess)
             {
                 await context.CallActivityAsync(
                     nameof(NotifyGameUpdatedActivity),
-                    new NotifyGameUpdatedActivityInput(createNewGameResult.Value));
+                    new NotifyGameUpdatedActivityInput(activity.TraceId.ToString(), activity.SpanId.ToString(), createNewGameResult.Value));
             }
             else
             {
@@ -31,13 +43,13 @@ internal class GameWorkflow : Workflow<GameWorkflowInput, Result>
             {
                 Result<Game> addBotPlayerResult = await context.CallActivityAsync<Result<Game>>(
                     nameof(AddBotPlayerActivity),
-                    new AddBotPlayerActivityInput(game.Id));
+                    new AddBotPlayerActivityInput(activity.TraceId.ToString(), activity.SpanId.ToString(), game.Id));
 
                 if (addBotPlayerResult.IsSuccess)
                 {
                     await context.CallActivityAsync(
                         nameof(NotifyGameUpdatedActivity),
-                        new NotifyGameUpdatedActivityInput(addBotPlayerResult.Value));
+                        new NotifyGameUpdatedActivityInput(activity.TraceId.ToString(), activity.SpanId.ToString(), addBotPlayerResult.Value));
 
                     game = addBotPlayerResult.Value;
                 }
@@ -49,17 +61,17 @@ internal class GameWorkflow : Workflow<GameWorkflowInput, Result>
 
             Result<StartNewRoundActivityOutput> startNewRoundActivityResult = await context.CallActivityAsync<Result<StartNewRoundActivityOutput>>(
                 nameof(StartNewRoundActivity),
-                new StartNewRoundActivityInput(game.Id));
+                new StartNewRoundActivityInput(activity.TraceId.ToString(), activity.SpanId.ToString(), game.Id));
 
             if (startNewRoundActivityResult.IsSuccess)
             {
                 await context.CallActivityAsync(
                     nameof(NotifyRoundStartedActivity),
-                    new NotifyRoundStartedActivityInput(startNewRoundActivityResult.Value.Round));
+                    new NotifyRoundStartedActivityInput(activity.TraceId.ToString(), activity.SpanId.ToString(), startNewRoundActivityResult.Value.Round));
 
                 await context.CallActivityAsync(
                     nameof(NotifyGameUpdatedActivity),
-                    new NotifyGameUpdatedActivityInput(startNewRoundActivityResult.Value.Game));
+                    new NotifyGameUpdatedActivityInput(activity.TraceId.ToString(), activity.SpanId.ToString(), startNewRoundActivityResult.Value.Game));
             }
             else
             {
@@ -69,7 +81,7 @@ internal class GameWorkflow : Workflow<GameWorkflowInput, Result>
             CardsPassedEvent cardsPassedEvent = await context.WaitForExternalEventAsync<CardsPassedEvent>(GameWorkflowEvents.CardsPassed);
             await context.CallActivityAsync(
                 nameof(CardsPassedActivity),
-                cardsPassedEvent);
+                new CardsPassedActivityInput(activity.TraceId.ToString(), activity.SpanId.ToString(), cardsPassedEvent));
 
             // Start the game
 
@@ -77,6 +89,7 @@ internal class GameWorkflow : Workflow<GameWorkflowInput, Result>
         }
         catch (Exception ex)
         {
+            activity.AddException(ex);
             return Result.Error(ex.Message);
         }
 

--- a/src/Hearts.Api/Workflows/GameWorkflowInput.cs
+++ b/src/Hearts.Api/Workflows/GameWorkflowInput.cs
@@ -1,5 +1,6 @@
+using System.Diagnostics;
 using Hearts.Contracts;
 
 namespace Hearts.Api.Workflows;
 
-record GameWorkflowInput(Player Player);
+record GameWorkflowInput(string TraceId, string SpanId, Player Player);

--- a/src/Hearts.Api/Workflows/NotifyGameUpdatedActivity.cs
+++ b/src/Hearts.Api/Workflows/NotifyGameUpdatedActivity.cs
@@ -10,7 +10,7 @@ internal class NotifyGameUpdatedActivity(IClientCallback clientCallback, Instrum
     public override async Task<Result> RunAsync(WorkflowActivityContext context, NotifyGameUpdatedActivityInput input)
     {
         ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(NotifyGameUpdatedActivity), ActivityKind.Internal, activityContext);
+        using Activity? activity = instrumentation.StartActivity(nameof(NotifyGameUpdatedActivity), ActivityKind.Internal, activityContext);
 
         try
         {

--- a/src/Hearts.Api/Workflows/NotifyGameUpdatedActivity.cs
+++ b/src/Hearts.Api/Workflows/NotifyGameUpdatedActivity.cs
@@ -1,12 +1,17 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using Dapr.Workflow;
+using Hearts.Api.OpenTelemetry;
 
 namespace Hearts.Api.Workflows;
 
-internal class NotifyGameUpdatedActivity(IClientCallback clientCallback) : WorkflowActivity<NotifyGameUpdatedActivityInput, Result>
+internal class NotifyGameUpdatedActivity(IClientCallback clientCallback, Instrumentation instrumentation) : WorkflowActivity<NotifyGameUpdatedActivityInput, Result>
 {
     public override async Task<Result> RunAsync(WorkflowActivityContext context, NotifyGameUpdatedActivityInput input)
     {
+        ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
+        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(NotifyGameUpdatedActivity), ActivityKind.Internal, activityContext);
+
         try
         {
             await clientCallback.GameUpdated(input.Game);
@@ -14,6 +19,7 @@ internal class NotifyGameUpdatedActivity(IClientCallback clientCallback) : Workf
         }
         catch (Exception ex)
         {
+            activity?.AddException(ex);
             return Result.Error(ex.Message);
         }
     }

--- a/src/Hearts.Api/Workflows/NotifyGameUpdatedActivityInput.cs
+++ b/src/Hearts.Api/Workflows/NotifyGameUpdatedActivityInput.cs
@@ -2,4 +2,4 @@ using Hearts.Contracts;
 
 namespace Hearts.Api.Workflows;
 
-record NotifyGameUpdatedActivityInput(Game Game);
+record NotifyGameUpdatedActivityInput(string TraceId, string SpanId, Game Game);

--- a/src/Hearts.Api/Workflows/NotifyRoundStartedActivity.cs
+++ b/src/Hearts.Api/Workflows/NotifyRoundStartedActivity.cs
@@ -10,7 +10,7 @@ internal class NotifyRoundStartedActivity(IClientCallback clientCallback, Instru
     public override async Task<Result> RunAsync(WorkflowActivityContext context, NotifyRoundStartedActivityInput input)
     {
         ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(NotifyGameUpdatedActivity), ActivityKind.Internal, activityContext);
+        using Activity? activity = instrumentation.StartActivity(nameof(NotifyGameUpdatedActivity), ActivityKind.Internal, activityContext);
 
         try
         {

--- a/src/Hearts.Api/Workflows/NotifyRoundStartedActivityInput.cs
+++ b/src/Hearts.Api/Workflows/NotifyRoundStartedActivityInput.cs
@@ -1,3 +1,3 @@
 namespace Hearts.Api.Workflows;
 
-record NotifyRoundStartedActivityInput(Contracts.Round Round);
+record NotifyRoundStartedActivityInput(string TraceId, string SpanId, Contracts.Round Round);

--- a/src/Hearts.Api/Workflows/StartNewRoundActivity.cs
+++ b/src/Hearts.Api/Workflows/StartNewRoundActivity.cs
@@ -1,16 +1,21 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Ardalis.Result;
 using Dapr.Actors;
 using Dapr.Actors.Client;
 using Dapr.Workflow;
 using Hearts.Api.Actors;
+using Hearts.Api.OpenTelemetry;
 
 namespace Hearts.Api.Workflows;
 
-class StartNewRoundActivity(IActorProxyFactory actorProxyFactory) : WorkflowActivity<StartNewRoundActivityInput, Result<StartNewRoundActivityOutput>>
+class StartNewRoundActivity(IActorProxyFactory actorProxyFactory, Instrumentation instrumentation) : WorkflowActivity<StartNewRoundActivityInput, Result<StartNewRoundActivityOutput>>
 {
     public override async Task<Result<StartNewRoundActivityOutput>> RunAsync(WorkflowActivityContext context, StartNewRoundActivityInput input)
     {
+        ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
+        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(StartNewRoundActivity), ActivityKind.Internal, activityContext);
+
         try
         {
             ActorProxyOptions actorProxyOptions = new()

--- a/src/Hearts.Api/Workflows/StartNewRoundActivity.cs
+++ b/src/Hearts.Api/Workflows/StartNewRoundActivity.cs
@@ -14,7 +14,7 @@ class StartNewRoundActivity(IActorProxyFactory actorProxyFactory, Instrumentatio
     public override async Task<Result<StartNewRoundActivityOutput>> RunAsync(WorkflowActivityContext context, StartNewRoundActivityInput input)
     {
         ActivityContext activityContext = new(ActivityTraceId.CreateFromString(input.TraceId), ActivitySpanId.CreateFromString(input.SpanId), ActivityTraceFlags.Recorded);
-        using Activity? activity = instrumentation.ActivitySource.StartActivity(nameof(StartNewRoundActivity), ActivityKind.Internal, activityContext);
+        using Activity? activity = instrumentation.StartActivity(nameof(StartNewRoundActivity), ActivityKind.Internal, activityContext);
 
         try
         {

--- a/src/Hearts.Api/Workflows/StartNewRoundActivityInput.cs
+++ b/src/Hearts.Api/Workflows/StartNewRoundActivityInput.cs
@@ -1,3 +1,3 @@
 namespace Hearts.Api.Workflows;
 
-record StartNewRoundActivityInput(Guid GameId);
+record StartNewRoundActivityInput(string TraceId, string SpanId, Guid GameId);

--- a/src/Hearts.BlazorApp/Pages/GameTable.razor
+++ b/src/Hearts.BlazorApp/Pages/GameTable.razor
@@ -169,6 +169,8 @@
             roundPlayer.CardsToPass = [];
         }
 
+        passButtonDisabled = true;
+
         StateHasChanged();        
                 
         await SignalRService.PassCards(game!, passCards);

--- a/src/Hearts.BlazorApp/wwwroot/css/site.css
+++ b/src/Hearts.BlazorApp/wwwroot/css/site.css
@@ -608,14 +608,8 @@
   .h-20 {
     height: calc(var(--spacing) * 20);
   }
-  .h-30 {
-    height: calc(var(--spacing) * 30);
-  }
   .h-32 {
     height: calc(var(--spacing) * 32);
-  }
-  .h-36 {
-    height: calc(var(--spacing) * 36);
   }
   .h-40 {
     height: calc(var(--spacing) * 40);

--- a/src/Hearts.BlazorApp/wwwroot/css/site.css
+++ b/src/Hearts.BlazorApp/wwwroot/css/site.css
@@ -608,8 +608,14 @@
   .h-20 {
     height: calc(var(--spacing) * 20);
   }
+  .h-30 {
+    height: calc(var(--spacing) * 30);
+  }
   .h-32 {
     height: calc(var(--spacing) * 32);
+  }
+  .h-36 {
+    height: calc(var(--spacing) * 36);
   }
   .h-40 {
     height: calc(var(--spacing) * 40);

--- a/test/Hearts.Api.UnitTests/GameHubUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/GameHubUnitTests.cs
@@ -1,9 +1,12 @@
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
 using Dapr.Workflow;
+using Hearts.Api.Workflows;
 using Hearts.Contracts;
 using Microsoft.AspNetCore.SignalR;
 using NSubstitute;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace Hearts.Api.UnitTests;
 
@@ -54,6 +57,27 @@ public class GameHubUnitTests
     {
         [Theory, AutoNSubstituteData]
         internal async Task create_new_game(
+            [Substitute, Frozen] DaprWorkflowClient daprWorkflowClient,
+            GameHub sut,
+            Player player)
+        {
+            // Arrange
+
+            using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource("Hearts.Api")
+                .Build();
+
+            // Act
+
+            await sut.CreateNewGame(player);
+
+            // Assert
+
+            Assert.NotNull(daprWorkflowClient);
+        }
+
+        [Theory, AutoNSubstituteData]
+        internal async Task do_not_create_new_game_when_activity_is_null(
             [Substitute, Frozen] DaprWorkflowClient daprWorkflowClient,
             GameHub sut,
             Player player)

--- a/test/Hearts.Api.UnitTests/OpenTelemetry/InstrumentationUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/OpenTelemetry/InstrumentationUnitTests.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using Hearts.Api.OpenTelemetry;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Hearts.Api.UnitTests.OpenTelemetry;
+
+public class InstrumentationUnitTests
+{
+    [Theory, AutoNSubstituteData]
+    internal void start_activity_given_name(
+        Instrumentation sut,
+        string name)
+    {
+        // Arrange
+
+        using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Hearts.Api")
+            .Build();
+
+        // Act
+
+        Activity? activity = sut.StartActivity(name);
+
+        // Assert
+
+        Assert.Equal(name, activity?.DisplayName);
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void start_activity_given_name_kind_context(
+        Instrumentation sut,
+        string name,
+        ActivityKind activityKind,
+        ActivityContext activityContext)
+    {
+        // Arrange
+
+        using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Hearts.Api")
+            .Build();
+
+        // Act
+
+        Activity? activity = sut.StartActivity(name, activityKind, activityContext);
+
+        // Assert
+
+        Assert.Equal(name, activity?.DisplayName);
+        Assert.Equal(activityKind, activity?.Kind);
+        Assert.Equal(activityContext.TraceId, activity?.TraceId);
+        Assert.Equal(activityContext.SpanId, activity?.ParentSpanId);
+    }
+}

--- a/test/Hearts.Api.UnitTests/Workflows/AddBotPlayerActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/AddBotPlayerActivityUnitTests.cs
@@ -10,6 +10,8 @@ using Hearts.Api.Workflows;
 using Hearts.Contracts;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace Hearts.Api.UnitTests.Workflows;
 
@@ -55,6 +57,10 @@ public class AddBotPlayerActivityUnitTests
         AddBotPlayerActivity sut)
     {
         // Arrange
+
+        using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Hearts.Api")
+            .Build();
 
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
             .Throws<Exception>();

--- a/test/Hearts.Api.UnitTests/Workflows/AddBotPlayerActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/AddBotPlayerActivityUnitTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
@@ -30,6 +31,12 @@ public class AddBotPlayerActivityUnitTests
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
             .Returns(gameActor);
 
+        addBotPlayerActivityInput = addBotPlayerActivityInput with
+            {
+                TraceId = ActivityTraceId.CreateRandom().ToString(),
+                SpanId = ActivitySpanId.CreateRandom().ToString()
+            };
+
         // Act
 
         Result<Game> result = await sut.RunAsync(workflowContext, addBotPlayerActivityInput);
@@ -51,6 +58,12 @@ public class AddBotPlayerActivityUnitTests
 
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
             .Throws<Exception>();
+
+        addBotPlayerActivityInput = addBotPlayerActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 

--- a/test/Hearts.Api.UnitTests/Workflows/AddBotPlayerActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/AddBotPlayerActivityUnitTests.cs
@@ -79,4 +79,31 @@ public class AddBotPlayerActivityUnitTests
 
         Assert.True(result.IsError());
     }
+
+    [Theory, AutoNSubstituteData]
+    internal async Task return_error_when_exception_was_thrown_given_no_activity(
+        [Substitute, Frozen] WorkflowActivityContext workflowContext,
+        [Substitute, Frozen] IActorProxyFactory actorProxyFactory,
+        AddBotPlayerActivityInput addBotPlayerActivityInput,
+        AddBotPlayerActivity sut)
+    {
+        // Arrange        
+
+        actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
+            .Throws<Exception>();
+
+        addBotPlayerActivityInput = addBotPlayerActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
+        // Act
+
+        Result<Game> result = await sut.RunAsync(workflowContext, addBotPlayerActivityInput);
+
+        // Assert
+
+        Assert.True(result.IsError());
+    }
 }

--- a/test/Hearts.Api.UnitTests/Workflows/CardsPassedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/CardsPassedActivityUnitTests.cs
@@ -9,6 +9,8 @@ using Hearts.Api.Actors;
 using Hearts.Api.Workflows;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace Hearts.Api.UnitTests.Workflows;
 
@@ -45,6 +47,10 @@ public class CardsPassedActivityUnitTests
         CardsPassedActivityInput cardsPassedActivityInput)
     {
         // Arrange
+
+        using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Hearts.Api")
+            .Build();
 
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), Arg.Any<string>(), Arg.Any<ActorProxyOptions>())
             .Throws(new Exception());

--- a/test/Hearts.Api.UnitTests/Workflows/CardsPassedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/CardsPassedActivityUnitTests.cs
@@ -69,4 +69,31 @@ public class CardsPassedActivityUnitTests
 
         Assert.True(result.IsError());
     }
+
+    [Theory, AutoNSubstituteData]
+    internal async Task return_error_when_exception_was_thrown_given_no_activity(
+        [Substitute, Frozen] IActorProxyFactory actorProxyFactory,
+        [Substitute, Frozen] WorkflowActivityContext workflowActivityContext,
+        CardsPassedActivity sut,
+        CardsPassedActivityInput cardsPassedActivityInput)
+    {
+        // Arrange
+
+        actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), Arg.Any<string>(), Arg.Any<ActorProxyOptions>())
+            .Throws(new Exception());
+
+        cardsPassedActivityInput = cardsPassedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
+        // Act
+
+        Result result = await sut.RunAsync(workflowActivityContext, cardsPassedActivityInput);
+
+        // Assert
+
+        Assert.True(result.IsError());
+    }
 }

--- a/test/Hearts.Api.UnitTests/Workflows/CardsPassedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/CardsPassedActivityUnitTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
@@ -17,13 +18,19 @@ public class CardsPassedActivityUnitTests
     internal async Task return_success_when_pass_cards_completes(
         [Substitute, Frozen] WorkflowActivityContext workflowActivityContext,
         CardsPassedActivity sut,
-        CardsPassedEvent cardsPassedEvent)
+        CardsPassedActivityInput cardsPassedActivityInput)
     {
         // Arrange
 
+        cardsPassedActivityInput = cardsPassedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
         // Act
 
-        Result result = await sut.RunAsync(workflowActivityContext, cardsPassedEvent);
+        Result result = await sut.RunAsync(workflowActivityContext, cardsPassedActivityInput);
 
         // Assert
 
@@ -35,16 +42,22 @@ public class CardsPassedActivityUnitTests
         [Substitute, Frozen] IActorProxyFactory actorProxyFactory,
         [Substitute, Frozen] WorkflowActivityContext workflowActivityContext,
         CardsPassedActivity sut,
-        CardsPassedEvent cardsPassedEvent)
+        CardsPassedActivityInput cardsPassedActivityInput)
     {
         // Arrange
 
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), Arg.Any<string>(), Arg.Any<ActorProxyOptions>())
             .Throws(new Exception());
 
+        cardsPassedActivityInput = cardsPassedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
         // Act
 
-        Result result = await sut.RunAsync(workflowActivityContext, cardsPassedEvent);
+        Result result = await sut.RunAsync(workflowActivityContext, cardsPassedActivityInput);
 
         // Assert
 

--- a/test/Hearts.Api.UnitTests/Workflows/CreateNewGameActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/CreateNewGameActivityUnitTests.cs
@@ -79,4 +79,31 @@ public class CreateNewGameActivityUnitTests
 
         Assert.True(result.IsError());
     }
+
+    [Theory, AutoNSubstituteData]
+    internal async Task return_error_when_exception_was_thrown_given_no_activity(
+        [Substitute, Frozen] WorkflowActivityContext workflowContext,
+        [Substitute, Frozen] IActorProxyFactory actorProxyFactory,
+        CreateNewGameActivityInput createNewGameActivityInput,
+        CreateNewGameActivity sut)
+    {
+        // Arrange
+
+        actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
+            .Throws<Exception>();
+
+        createNewGameActivityInput = createNewGameActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
+        // Act
+
+        Result<Game> result = await sut.RunAsync(workflowContext, createNewGameActivityInput);
+
+        // Assert
+
+        Assert.True(result.IsError());
+    }
 }

--- a/test/Hearts.Api.UnitTests/Workflows/CreateNewGameActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/CreateNewGameActivityUnitTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
@@ -30,6 +31,12 @@ public class CreateNewGameActivityUnitTests
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
             .Returns(gameActor);
 
+        createNewGameActivityInput = createNewGameActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
         // Act
 
         Result<Game> result = await sut.RunAsync(workflowContext, createNewGameActivityInput);
@@ -51,6 +58,12 @@ public class CreateNewGameActivityUnitTests
 
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
             .Throws<Exception>();
+
+        createNewGameActivityInput = createNewGameActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 

--- a/test/Hearts.Api.UnitTests/Workflows/CreateNewGameActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/CreateNewGameActivityUnitTests.cs
@@ -10,6 +10,8 @@ using Hearts.Api.Workflows;
 using Hearts.Contracts;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace Hearts.Api.UnitTests.Workflows;
 
@@ -55,6 +57,10 @@ public class CreateNewGameActivityUnitTests
         CreateNewGameActivity sut)
     {
         // Arrange
+
+        using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Hearts.Api")
+            .Build();
 
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
             .Throws<Exception>();

--- a/test/Hearts.Api.UnitTests/Workflows/GameWorkflowUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/GameWorkflowUnitTests.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
 using Dapr.Workflow;
+using Hearts.Api.OpenTelemetry;
 using Hearts.Api.Workflows;
 using Hearts.Contracts;
 using NSubstitute;
@@ -13,7 +15,9 @@ public class GameWorkflowUnitTests
 {
     [Theory, AutoNSubstituteData]
     internal async Task return_success_when_workflow_runs_ok(
+        [Substitute, Frozen] Instrumentation instrumentation,
         [Substitute, Frozen] WorkflowContext workflowContext,
+        Activity activity,
         GameWorkflowInput gameWorkflowInput,
         GameWorkflow sut,
         Round round,
@@ -45,6 +49,17 @@ public class GameWorkflowUnitTests
 
         workflowContext.WaitForExternalEventAsync<CardsPassedEvent>(GameWorkflowEvents.CardsPassed)
             .Returns(cardsPassedEvent);
+
+        instrumentation.StartActivity(nameof(GameWorkflow), ActivityKind.Internal, Arg.Any<ActivityContext>())
+           .Returns(activity);
+
+        sut.Instrumentation = instrumentation;
+
+        gameWorkflowInput = gameWorkflowInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 
@@ -79,12 +94,14 @@ public class GameWorkflowUnitTests
 
         await workflowContext.Received().CallActivityAsync(
             nameof(CardsPassedActivity),
-            cardsPassedEvent);
+            Arg.Any<CardsPassedActivityInput>());
     }
 
     [Theory, AutoNSubstituteData]
     internal async Task return_error_when_game_could_not_be_created(
+        [Substitute, Frozen] Instrumentation instrumentation,
         [Substitute, Frozen] WorkflowContext workflowContext,
+        Activity activity,
         GameWorkflowInput gameWorkflowInput,
         GameWorkflow sut)
     {
@@ -94,6 +111,17 @@ public class GameWorkflowUnitTests
             nameof(CreateNewGameActivity),
             Arg.Any<CreateNewGameActivityInput>())
         .Returns(Result.Error("Failed to create new game"));
+
+        instrumentation.StartActivity(nameof(GameWorkflow), ActivityKind.Internal, Arg.Any<ActivityContext>())
+            .Returns(activity);
+
+        sut.Instrumentation = instrumentation;
+
+        gameWorkflowInput = gameWorkflowInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 
@@ -114,7 +142,9 @@ public class GameWorkflowUnitTests
 
     [Theory, AutoNSubstituteData]
     internal async Task return_error_when_bot_player_could_not_be_added(
+        [Substitute, Frozen] Instrumentation instrumentation,
         [Substitute, Frozen] WorkflowContext workflowContext,
+        Activity activity,
         GameWorkflowInput gameWorkflowInput,
         GameWorkflow sut)
     {
@@ -131,6 +161,17 @@ public class GameWorkflowUnitTests
             nameof(AddBotPlayerActivity),
             Arg.Any<AddBotPlayerActivityInput>())
         .Returns(Result.Error("Failed to add bot player"));
+
+        instrumentation.StartActivity(nameof(GameWorkflow), ActivityKind.Internal, Arg.Any<ActivityContext>())
+            .Returns(activity);
+
+        sut.Instrumentation = instrumentation;
+
+        gameWorkflowInput = gameWorkflowInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 
@@ -155,7 +196,9 @@ public class GameWorkflowUnitTests
 
     [Theory, AutoNSubstituteData]
     internal async Task return_error_when_round_could_not_be_started(
+        [Substitute, Frozen] Instrumentation instrumentation,
         [Substitute, Frozen] WorkflowContext workflowContext,
+        Activity activity,
         GameWorkflowInput gameWorkflowInput,
         GameWorkflow sut)
     {
@@ -182,6 +225,17 @@ public class GameWorkflowUnitTests
             nameof(StartNewRoundActivity),
             Arg.Any<StartNewRoundActivityInput>())
         .Returns(Result.Error("Failed to start new round"));
+
+        instrumentation.StartActivity(nameof(GameWorkflow), ActivityKind.Internal, Arg.Any<ActivityContext>())
+            .Returns(activity);
+
+        sut.Instrumentation = instrumentation;
+
+        gameWorkflowInput = gameWorkflowInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 
@@ -214,7 +268,9 @@ public class GameWorkflowUnitTests
 
     [Theory, AutoNSubstituteData]
     internal async Task return_error_when_exception_is_thrown(
+        [Substitute, Frozen] Instrumentation instrumentation,
         [Substitute, Frozen] WorkflowContext workflowContext,
+        Activity activity,
         GameWorkflowInput gameWorkflowInput,
         GameWorkflow sut)
     {
@@ -224,6 +280,17 @@ public class GameWorkflowUnitTests
             nameof(CreateNewGameActivity),
             Arg.Any<CreateNewGameActivityInput>())
         .ThrowsAsync<Exception>();
+
+        instrumentation.StartActivity(nameof(GameWorkflow), ActivityKind.Internal, Arg.Any<ActivityContext>())
+            .Returns(activity);
+
+        sut.Instrumentation = instrumentation;
+
+        gameWorkflowInput = gameWorkflowInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 

--- a/test/Hearts.Api.UnitTests/Workflows/GameWorkflowUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/GameWorkflowUnitTests.cs
@@ -104,12 +104,7 @@ public class GameWorkflowUnitTests
         GameWorkflowInput gameWorkflowInput,
         GameWorkflow sut)
     {
-        // Arrange
-
-        workflowContext.CallActivityAsync<Result<Game>>(
-            nameof(CreateNewGameActivity),
-            Arg.Any<CreateNewGameActivityInput>())
-        .Returns(Result.Error("Failed to create new game"));
+        // Arrange        
 
         gameWorkflowInput = gameWorkflowInput with
         {

--- a/test/Hearts.Api.UnitTests/Workflows/NotifyGameUpdatedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/NotifyGameUpdatedActivityUnitTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
@@ -18,6 +19,12 @@ public class NotifyGameUpdatedActivityUnitTests
         NotifyGameUpdatedActivity sut)
     {
         // Arrange
+
+        notifyGameUpdatedActivityInput = notifyGameUpdatedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 
@@ -41,6 +48,12 @@ public class NotifyGameUpdatedActivityUnitTests
 
         clientCallback.GameUpdated(notifyGameUpdatedActivityInput.Game)
             .ThrowsAsync<Exception>();
+
+        notifyGameUpdatedActivityInput = notifyGameUpdatedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 

--- a/test/Hearts.Api.UnitTests/Workflows/NotifyGameUpdatedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/NotifyGameUpdatedActivityUnitTests.cs
@@ -69,4 +69,31 @@ public class NotifyGameUpdatedActivityUnitTests
 
         Assert.True(result.IsError());
     }
+
+    [Theory, AutoNSubstituteData]
+    internal async Task return_error_when_exception_was_thrown_given_no_activity(
+        [Substitute, Frozen] WorkflowActivityContext workflowContext,
+        [Substitute, Frozen] IClientCallback clientCallback,
+        NotifyGameUpdatedActivityInput notifyGameUpdatedActivityInput,
+        NotifyGameUpdatedActivity sut)
+    {
+        // Arrange
+
+        clientCallback.GameUpdated(notifyGameUpdatedActivityInput.Game)
+            .ThrowsAsync<Exception>();
+
+        notifyGameUpdatedActivityInput = notifyGameUpdatedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
+        // Act
+
+        Result result = await sut.RunAsync(workflowContext, notifyGameUpdatedActivityInput);
+
+        // Assert
+
+        Assert.True(result.IsError());
+    }
 }

--- a/test/Hearts.Api.UnitTests/Workflows/NotifyGameUpdatedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/NotifyGameUpdatedActivityUnitTests.cs
@@ -6,6 +6,8 @@ using Dapr.Workflow;
 using Hearts.Api.Workflows;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace Hearts.Api.UnitTests.Workflows;
 
@@ -45,6 +47,10 @@ public class NotifyGameUpdatedActivityUnitTests
         NotifyGameUpdatedActivity sut)
     {
         // Arrange
+
+        using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Hearts.Api")
+            .Build();
 
         clientCallback.GameUpdated(notifyGameUpdatedActivityInput.Game)
             .ThrowsAsync<Exception>();

--- a/test/Hearts.Api.UnitTests/Workflows/NotifyRoundStartedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/NotifyRoundStartedActivityUnitTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
@@ -18,6 +19,12 @@ public class NotifyRoundStartedActivityUnitTests
         NotifyRoundStartedActivity sut)
     {
         // Arrange
+
+        notifyRoundStartedActivityInput = notifyRoundStartedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 
@@ -41,6 +48,12 @@ public class NotifyRoundStartedActivityUnitTests
 
         clientCallback.RoundStarted(notifyRoundStartedActivityInput.Round)
             .ThrowsAsync<Exception>();
+
+        notifyRoundStartedActivityInput = notifyRoundStartedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 

--- a/test/Hearts.Api.UnitTests/Workflows/NotifyRoundStartedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/NotifyRoundStartedActivityUnitTests.cs
@@ -6,6 +6,8 @@ using Dapr.Workflow;
 using Hearts.Api.Workflows;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace Hearts.Api.UnitTests.Workflows;
 
@@ -45,6 +47,10 @@ public class NotifyRoundStartedActivityUnitTests
         NotifyRoundStartedActivity sut)
     {
         // Arrange
+
+        using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("Hearts.Api")
+            .Build();
 
         clientCallback.RoundStarted(notifyRoundStartedActivityInput.Round)
             .ThrowsAsync<Exception>();

--- a/test/Hearts.Api.UnitTests/Workflows/NotifyRoundStartedActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/NotifyRoundStartedActivityUnitTests.cs
@@ -69,4 +69,31 @@ public class NotifyRoundStartedActivityUnitTests
 
         Assert.True(result.IsError());
     }
+
+    [Theory, AutoNSubstituteData]
+    internal async Task return_error_when_exception_was_thrown_given_no_activity(
+        [Substitute, Frozen] WorkflowActivityContext workflowContext,
+        [Substitute, Frozen] IClientCallback clientCallback,
+        NotifyRoundStartedActivityInput notifyRoundStartedActivityInput,
+        NotifyRoundStartedActivity sut)
+    {
+        // Arrange        
+
+        clientCallback.RoundStarted(notifyRoundStartedActivityInput.Round)
+            .ThrowsAsync<Exception>();
+
+        notifyRoundStartedActivityInput = notifyRoundStartedActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
+        // Act
+
+        Result result = await sut.RunAsync(workflowContext, notifyRoundStartedActivityInput);
+
+        // Assert
+
+        Assert.True(result.IsError());
+    }
 }

--- a/test/Hearts.Api.UnitTests/Workflows/StartNewRoundActivityUnitTests.cs
+++ b/test/Hearts.Api.UnitTests/Workflows/StartNewRoundActivityUnitTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Ardalis.Result;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
@@ -29,6 +30,12 @@ public class StartNewRoundActivityUnitTests
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
             .Returns(gameActor);
 
+        startNewRoundActivityInput = startNewRoundActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
+
         // Act
 
         Result<StartNewRoundActivityOutput> result = await sut.RunAsync(workflowContext, startNewRoundActivityInput);
@@ -49,6 +56,12 @@ public class StartNewRoundActivityUnitTests
 
         actorProxyFactory.CreateActorProxy<IGameActor>(Arg.Any<ActorId>(), nameof(GameActor), Arg.Any<ActorProxyOptions>())
             .Throws<Exception>();
+
+        startNewRoundActivityInput = startNewRoundActivityInput with
+        {
+            TraceId = ActivityTraceId.CreateRandom().ToString(),
+            SpanId = ActivitySpanId.CreateRandom().ToString()
+        };
 
         // Act
 


### PR DESCRIPTION
This pull request introduces OpenTelemetry tracing to the Hearts.Api project, adding instrumentation to various workflows and activities. The key changes include the addition of an `Instrumentation` class, updates to workflow and activity input classes to include trace and span IDs, and modifications to methods to start and manage tracing activities.

### Instrumentation Integration:

* [`src/Hearts.Api/OpenTelemetry/Instrumentation.cs`](diffhunk://#diff-32a7d68c9ddd1629ac2ec093da1d2abf877a3670bd3e5bc8bc2f0feb6af30d45R1-R18): Introduced a new `Instrumentation` class to handle activity creation and management.

### Workflow and Activity Updates:

* [`src/Hearts.Api/Workflows/GameWorkflow.cs`](diffhunk://#diff-dd1279f73407f896cf79cc62d619f02febe916c5c3bfa32719d9b7df6931cd4bR1-R33): Added `Instrumentation` property and updated methods to start activities with the trace and span IDs.
* `src/Hearts.Api/Workflows/AddBotPlayerActivity.cs`, `src/Hearts.Api/Workflows/CardsPassedActivity.cs`, `src/Hearts.Api/Workflows/CreateNewGameActivity.cs`, `src/Hearts.Api/Workflows/NotifyGameUpdatedActivity.cs`, `src/Hearts.Api/Workflows/NotifyRoundStartedActivity.cs`: Updated constructors to accept `Instrumentation` and added activity creation in `RunAsync` methods. [[1]](diffhunk://#diff-b92cf1b9827a03eb7c601ca7b69822831fe3a3cedce8ff0d46d1bf210efcb6f8R1-R19) [[2]](diffhunk://#diff-da66cb777ccaffb50cc57218894b16b07dd43900266500fe199014803c3a4878R1-R18) [[3]](diffhunk://#diff-67764d0f0da76eb6af93a526f3b4f8e4eb47daa3b22c7519d7d9d88ff4bb9d7aR1-R19) [[4]](diffhunk://#diff-44a5b313d9e446a0d14b4f871e2b43364f92d0ae3f0b1ea188d3b654ddb88ebcR1-R22) [[5]](diffhunk://#diff-3682f509fc523f66aa4b8085900901472ee1803d532aa713b908c4d041505e18R1-R22)

### Input Class Modifications:

* `src/Hearts.Api/Workflows/AddBotPlayerActivityInput.cs`, `src/Hearts.Api/Workflows/CardsPassedActivityInput.cs`, `src/Hearts.Api/Workflows/CreateNewGameActivityInput.cs`, `src/Hearts.Api/Workflows/GameWorkflowInput.cs`, `src/Hearts.Api/Workflows/NotifyGameUpdatedActivityInput.cs`, `src/Hearts.Api/Workflows/NotifyRoundStartedActivityInput.cs`: Updated input records to include `TraceId` and `SpanId` fields. (F25386caR1, [[1]](diffhunk://#diff-f5c18d2deb22810315adb55599a92d548e0399d7bb65db984f37a5b41f9605d8R1-R3) [[2]](diffhunk://#diff-5aaba8956eddd32c2105da868faf6c2779a05252201ccc82f74bf6cb8ed7fa2dR1-R6) [[3]](diffhunk://#diff-4de50c61e4e0da3ae1d561ac6cfc3661dc6a146c6d7bcd7b00ba82311e5e38bdR1-R6) F85bd7adR1, F2d479e0R1)

### Dependency Injection:

* `src/Hearts.Api/Program.cs`: Registered the `Instrumentation` service in the dependency injection container. (F2789d60R1)